### PR TITLE
Add torchvision version test

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-torchvision == 0.18.1
+torchvision >= 0.17.0

--- a/tests/transforms/test_augment.py
+++ b/tests/transforms/test_augment.py
@@ -8,6 +8,7 @@ from torch.utils.data.dataloader import default_collate
 import torchaug.transforms as transforms
 import torchaug.transforms.functional as F
 from torchaug import ta_tensors
+from importlib.metadata import version
 
 from ..utils import (
     IMAGE_MAKERS,
@@ -379,7 +380,7 @@ def test_labels_getter_default_heuristic(key, sample_type):
         d = {key: "something_else", "labels": labels}
         assert tv_transforms._utils._find_labels_default_heuristic(d) is labels
 
-
+@pytest.mark.skipif(version("torchvision") < "0.18.0", reason="requires torchvision>=0.18.0")
 class TestJPEG:
     @pytest.mark.parametrize("quality", [5, 75])
     @pytest.mark.parametrize("color_space", ["RGB", "GRAY"])

--- a/tests/transforms/test_color.py
+++ b/tests/transforms/test_color.py
@@ -1,4 +1,5 @@
 import re
+from importlib.metadata import version
 
 import pytest
 import torch
@@ -31,6 +32,7 @@ from ..utils import (
 )
 
 
+@pytest.mark.skipif(version("torchvision") < "0.18.0", reason="requires torchvision>=0.18.0")
 class TestRgbToGrayscale:
     @pytest.mark.parametrize("dtype", [torch.uint8, torch.float32])
     @pytest.mark.parametrize("device", cpu_and_cuda())

--- a/torchaug/_utils.py
+++ b/torchaug/_utils.py
@@ -37,3 +37,18 @@ def _log_api_usage_once(obj: Any) -> None:
     if isinstance(obj, FunctionType):
         name = obj.__name__
     torch._C._log_api_usage_once(f"{module}.{name}")
+
+
+def _assert_torchvision_installed(version: str) -> None:
+    """Asserts that the installed version of torchvision is at least the required version."""
+    from importlib.metadata import version as module_version
+
+    try:
+        import torchvision  # noqa: F401
+    except ImportError:
+        raise RuntimeError("Torchvision is not installed.")
+
+    if module_version("torchvision") < version:
+        raise RuntimeError(
+            f"Torchvision is not installed or the installed version is lower than the required version {version}."
+        )

--- a/torchaug/transforms/_augment.py
+++ b/torchaug/transforms/_augment.py
@@ -16,6 +16,7 @@ from torch.utils._pytree import tree_flatten, tree_unflatten
 from torchvision.transforms.v2._utils import _check_sequence_input, _parse_labels_getter, has_any, query_chw
 
 from torchaug import ta_tensors
+from torchaug._utils import _assert_torchvision_installed
 
 from . import functional as F
 from ._transform import RandomApplyTransform, Transform
@@ -170,6 +171,9 @@ class JPEG(Transform):
     The input is expected to be of a tensor of dtype uint8, on CPU, and have [..., 3 or 1, H, W] shape,
     where ... means an arbitrary number of leading dimensions.
 
+    .. warning::
+        This transform requires the torchvision package to be installed and at least version 0.18.0.
+
     Args:
         quality: JPEG quality, from 1 to 100. Lower means more compression.
             If quality is a sequence like (min, max), it specifies the range of JPEG quality to
@@ -180,7 +184,10 @@ class JPEG(Transform):
     """
 
     def __init__(self, quality: Union[int, Sequence[int]]):
+        _assert_torchvision_installed("0.18.0")
+
         super().__init__()
+
         if isinstance(quality, int):
             quality = [quality, quality]
         else:

--- a/torchaug/transforms/_color.py
+++ b/torchaug/transforms/_color.py
@@ -13,6 +13,8 @@ from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
 
 import torch
 
+from torchaug._utils import _assert_torchvision_installed
+
 from . import functional as F
 from ._transform import RandomApplyTransform, Transform
 from ._utils import query_chw
@@ -53,11 +55,15 @@ class Grayscale(Transform):
 class RGB(Transform):
     """Convert images or videos to RGB (if they are already not RGB).
 
+    .. warning::
+        This transform requires the torchvision package to be installed and at least version 0.18.0.
+
     If the input is a :class:`torch.Tensor`, it is expected
     to have [..., 1 or 3, H, W] shape, where ... means an arbitrary number of leading dimensions
     """
 
     def __init__(self):
+        _assert_torchvision_installed("0.18.0")
         super().__init__()
 
     def _transform(self, inpt: Any, params: Dict[str, Any]) -> Any:

--- a/torchaug/transforms/functional/_augment.py
+++ b/torchaug/transforms/functional/_augment.py
@@ -12,7 +12,7 @@ import torchvision.transforms.v2.functional as TVF
 from torchvision.io import decode_jpeg, encode_jpeg
 
 from torchaug import ta_tensors
-from torchaug._utils import _log_api_usage_once
+from torchaug._utils import _assert_torchvision_installed, _log_api_usage_once
 
 from ._utils._kernel import _get_kernel, _register_kernel_internal
 
@@ -67,6 +67,8 @@ def erase_video(
 
 def jpeg(image: torch.Tensor, quality: int) -> torch.Tensor:
     """See :class:`~torchaug.transforms.JPEG` for details."""
+    _assert_torchvision_installed("0.18.0")
+
     if torch.jit.is_scripting():
         return jpeg_image(image, quality=quality)
 
@@ -80,6 +82,8 @@ def jpeg(image: torch.Tensor, quality: int) -> torch.Tensor:
 @_register_kernel_internal(jpeg, ta_tensors.Image)
 @_register_kernel_internal(jpeg, ta_tensors.BatchImages)
 def jpeg_image(image: torch.Tensor, quality: int) -> torch.Tensor:
+    _assert_torchvision_installed("0.18.0")
+
     original_shape = image.shape
     image = image.view((-1,) + image.shape[-3:])
 

--- a/torchaug/transforms/functional/_color.py
+++ b/torchaug/transforms/functional/_color.py
@@ -14,7 +14,7 @@ import torchvision.transforms.v2.functional as TVF
 from torchvision.transforms.v2.functional._color import _hsv_to_rgb, _rgb_to_hsv
 
 from torchaug import ta_tensors
-from torchaug._utils import _log_api_usage_once
+from torchaug._utils import _assert_torchvision_installed, _log_api_usage_once
 
 from ._misc import to_dtype_image
 from ._utils._kernel import _get_kernel, _register_kernel_internal
@@ -67,6 +67,8 @@ def rgb_to_grayscale_video(video: torch.Tensor, num_output_channels: int = 1) ->
 
 def grayscale_to_rgb(inpt: torch.Tensor) -> torch.Tensor:
     """See :class:`~torchvision.transforms.v2.GrayscaleToRgb` for details."""
+    _assert_torchvision_installed("0.18.0")
+
     if torch.jit.is_scripting():
         return grayscale_to_rgb_image(inpt)
 
@@ -80,6 +82,8 @@ def grayscale_to_rgb(inpt: torch.Tensor) -> torch.Tensor:
 @_register_kernel_internal(grayscale_to_rgb, ta_tensors.Image)
 @_register_kernel_internal(grayscale_to_rgb, ta_tensors.BatchImages)
 def grayscale_to_rgb_image(image: torch.Tensor) -> torch.Tensor:
+    _assert_torchvision_installed("0.18.0")
+
     if image.shape[-3] >= 3:
         # Image already has RGB channels. We don't need to do anything.
         return image


### PR DESCRIPTION
Add the possibility to install previous version of torchvision by raising error on transforms that did not exist previously and skipping tests.